### PR TITLE
U/danielsf/generate instance catalogs

### DIFF
--- a/scripts/generateDc1InstCat.py
+++ b/scripts/generateDc1InstCat.py
@@ -2,6 +2,7 @@ from __future__ import with_statement
 import argparse
 import os
 import numpy as np
+import gzip
 
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogPoint
 from lsst.sims.catalogs.definitions import InstanceCatalog
@@ -119,9 +120,9 @@ if __name__ == "__main__":
         cat.phoSimHeaderMap = phosim_header_map
         with open(cat_name, 'w') as output:
             cat.write_header(output)
-            output.write('includeobj %s\n' % star_name)
-            output.write('includeobj %s\n' % gal_name)
-            output.write('includeobj %s\n' % agn_name)
+            output.write('includeobj %s.gz\n' % star_name)
+            output.write('includeobj %s.gz\n' % gal_name)
+            output.write('includeobj %s.gz\n' % agn_name)
 
         star_cat = MaskedPhoSimCatalogPoint(star_db, obs_metadata=obs)
         star_cat.phoSimHeaderMap = phosim_header_map
@@ -145,3 +146,10 @@ if __name__ == "__main__":
         cat = PhoSimCatalogZPoint(agn_db, obs_metadata=obs)
         cat.write_catalog(os.path.join(out_dir, agn_name), write_header=False,
                           chunk_size=100000)
+
+        for orig_name in (star_name, gal_name, agn_name):
+            full_name = os.path.join(out_dir, orig_name)
+            with open(full_name, 'r') as input_file:
+                with gzip.open(full_name+'.gz', 'w') as output_file:
+                    output_file.writelines(input_file)
+            os.unlink(full_name)

--- a/scripts/generateDc1InstCat.py
+++ b/scripts/generateDc1InstCat.py
@@ -29,8 +29,6 @@ class BrightStarCatalog(PhoSimCatalogPoint):
 
     min_mag = None
 
-    column_outputs = ['uniqueId', 'phoSimMagNorm']
-
     @cached
     def get_isBright(self):
         raw_norm = self.column_by_name('phoSimMagNorm')

--- a/scripts/generateDc1InstCat.py
+++ b/scripts/generateDc1InstCat.py
@@ -111,9 +111,9 @@ if __name__ == "__main__":
             obs.OpsimMetaData['rotTelPos'] = obs.OpsimMetaData['ditheredRotTelPos']
 
         cat_name = os.path.join(out_dir,'phosim_cat_%d.txt' % obshistid)
-        star_name = os.path.join('star_cat_%d.txt' % obshistid)
-        gal_name = os.path.join('gal_cat_%d.txt' % obshistid)
-        agn_name = os.path.join('agn_cat_%d.txt' % obshistid)
+        star_name = 'star_cat_%d.txt' % obshistid
+        gal_name = 'gal_cat_%d.txt' % obshistid
+        agn_name = 'agn_cat_%d.txt' % obshistid
 
         cat = PhoSimCatalogPoint(star_db, obs_metadata=obs)
         cat.phoSimHeaderMap = phosim_header_map

--- a/scripts/generateDc1InstCat.py
+++ b/scripts/generateDc1InstCat.py
@@ -1,0 +1,105 @@
+from __future__ import with_statement
+import argparse
+import os
+import numpy as np
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Generate an InstanceCatalog')
+    parser.add_argument('--db', type=str,
+                        default='minion_1016_sqlite_new_dithers.db',
+                        help='path to the OpSim database to query')
+    parser.add_argument('--out', type=str,
+                        default='.',
+                        help='directory where output will be written')
+    parser.add_argument('--id', type=int, nargs='+',
+                        default=None,
+                        help='obsHistID to generate InstanceCatalog for (a list)')
+    parser.add_argument('--dither', type=str,
+                        default='True',
+                        help='whether or not to apply dithering (true/false; default true)')
+    args = parser.parse_args()
+
+    obshistid_list = args.id
+    opsimdb = args.db
+    out_dir = args.out
+    dither_switch = True
+    if args.dither.lower()[0] == 'f':
+        dither_switch = False
+
+    from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
+
+    if not os.path.exists(opsimdb):
+        raise RuntimeError('%s does not exist' % opsimdb)
+
+    obs_generator = ObservationMetaDataGenerator(database=opsimdb, driver='sqlite')
+
+    from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogPoint
+    from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D
+    from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogZPoint
+    from lsst.sims.catUtils.exampleCatalogDefinitions import DefaultPhoSimHeaderMap
+    from lsst.sims.catUtils.baseCatalogModels import StarObj
+    from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj, GalaxyDiskObj
+    from lsst.sims.catUtils.baseCatalogModels import GalaxyAgnObj
+    from lsst.sims.utils import _getRotSkyPos
+    import copy
+
+    star_db = StarObj(database='LSSTCATSIM', host='fatboy.phys.washington.edu',
+                      port=1433, driver='mssql+pymssql')
+
+    bulge_db = GalaxyBulgeObj(connection=star_db.connection)
+    disk_db = GalaxyDiskObj(connection=star_db.connection)
+    agn_db = GalaxyAgnObj(connection=star_db.connection)
+
+    if not os.path.exists(out_dir):
+        os.mkdir(out_dir)
+
+    phosim_header_map = copy.deepcopy(DefaultPhoSimHeaderMap)
+    phosim_header_map['nsnap'] = 1
+    phosim_header_map['vistime'] = 30.0
+    phosim_header_map['camconfig'] = 1
+    for obshistid in obshistid_list:
+
+        obs_list = obs_generator.getObservationMetaData(obsHistID=obshistid,
+                                                        boundType='circle',
+                                                        boundLength=2.0)
+
+        obs = obs_list[0]
+        if dither_switch:
+            print 'dithering'
+            obs.pointingRA = np.degrees(obs.OpsimMetaData['randomDitherFieldPerVisitRA'])
+            obs.pointingDec = np.degrees(obs.OpsimMetaData['randomDitherFieldPerVisitDec'])
+            rotSky = _getRotSkyPos(obs._pointingRA, obs._pointingDec, obs,
+                                   obs.OpsimMetaData['ditheredRotTelPos'])
+
+            obs.rotSkyPos = np.degrees(rotSky)
+            obs.OpsimMetaData['rotTelPos'] = obs.OpsimMetaData['ditheredRotTelPos']
+
+        cat_name = os.path.join(out_dir,'phosim_cat_%d.txt' % obshistid)
+        star_name = os.path.join('star_cat_%d.txt' % obshistid)
+        gal_name = os.path.join('gal_cat_%d.txt' % obshistid)
+        agn_name = os.path.join('agn_cat_%d.txt' % obshistid)
+
+        cat = PhoSimCatalogPoint(star_db, obs_metadata=obs)
+
+        cat.phoSimHeaderMap = phosim_header_map
+        with open(cat_name, 'w') as output:
+            cat.write_header(output)
+            output.write('includeobj %s\n' % star_name)
+            output.write('includeobj %s\n' % gal_name)
+            output.write('includeobj %s\n' % agn_name)
+
+        cat.write_catalog(os.path.join(out_dir, star_name), write_header=False,
+                          chunk_size=100000)
+
+        cat = PhoSimCatalogSersic2D(bulge_db, obs_metadata=obs)
+        cat.write_catalog(os.path.join(out_dir, gal_name), write_header=False,
+                          chunk_size=100000)
+        cat = PhoSimCatalogSersic2D(disk_db, obs_metadata=obs)
+        cat.write_catalog(os.path.join(out_dir, gal_name), write_header=False,
+                          write_mode='a', chunk_size=100000)
+
+        cat = PhoSimCatalogZPoint(agn_db, obs_metadata=obs)
+        cat.write_catalog(os.path.join(out_dir, agn_name), write_header=False,
+                          chunk_size=100000)


### PR DESCRIPTION
This PR modifies the generateDc1InstCat.py script so that it will

1) replace stars with magnitude<min_mag with stars of mag=min_mag in the InstanceCatalog

2) keep track of the stars it replaced in catalogs named like output_dir/bright_stars_N.txt (where N is the obsHistID of the observation).  These catalogs contain the uniqueId of the replaced stars and their true magnitudes.